### PR TITLE
Var app is already defined in MyApp constructor

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,7 +100,7 @@ var MyApp = window.MyApp || (function(document, window){
 	 * @type {Object} 
 	 * @default {Object} 
 	 */
-	var app = {
+	app = {
 
 		/**
 		 * The init method, is the function that initialize the project,  


### PR DESCRIPTION
Removed var from app object declaration, as it is already declared inside MyApp constructor as a variable, alongside _private.
